### PR TITLE
refactor: Convert canvas image to WebP format to optimize server traffic

### DIFF
--- a/client/src/components/canvas/GameCanvas.tsx
+++ b/client/src/components/canvas/GameCanvas.tsx
@@ -89,14 +89,14 @@ const GameCanvas = ({
     if (roomStatus !== RoomStatus.DRAWING || !isHost) return;
 
     const sendCanvasImage = async () => {
-      const uint8Array = await getCanvasUint8Array(canvasRef);
+      const uint8Array = await getCanvasUint8Array(canvasRef, 'image/webp', 0.8);
       if (!uint8Array) return;
       void gameSocketHandlers.checkDrawing({ image: uint8Array });
     };
 
     const canvasCaptureInterval = setInterval(() => {
       void sendCanvasImage();
-    }, 10000);
+    }, 15000);
 
     return () => clearInterval(canvasCaptureInterval);
   }, [roomStatus, isHost]);

--- a/client/src/hooks/canvas/useDrawingOperation.ts
+++ b/client/src/hooks/canvas/useDrawingOperation.ts
@@ -135,7 +135,8 @@ export const useDrawingOperation = (
     if (!state.crdtRef.current) return;
 
     const { canvas, ctx } = getCanvasContext(canvasRef);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#FFFFFF';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     const activeStrokes = state.crdtRef.current.getActiveStrokes();
     for (const { stroke } of activeStrokes) {
@@ -229,7 +230,8 @@ export const useDrawingOperation = (
 
   const clearCanvas = useCallback(() => {
     const { canvas, ctx } = getCanvasContext(canvasRef);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#FFFFFF';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
   }, []);
 
   return {

--- a/client/src/utils/checkWebPSupport.ts
+++ b/client/src/utils/checkWebPSupport.ts
@@ -1,3 +1,18 @@
+/**
+ * WebP 이미지 포맷을 지원하는지 확인하는 함수입니다.
+ *
+ * 이 함수는 브라우저에서 WebP 포맷을 지원하는지 여부를 확인하여,
+ * 지원하면 `true`를, 지원하지 않으면 `false`를 반환합니다.
+ *
+ * @returns {boolean} WebP 포맷 지원 여부
+ *
+ * @example
+ * ```typescript
+ * const webpSupported = checkWebPSupport();
+ * ```
+ * @category Utils
+ */
+
 export function checkWebPSupport() {
   const canvas = document.createElement('canvas');
   return canvas.toDataURL('image/webp').indexOf('data:image/webp') === 0;

--- a/client/src/utils/checkWebPSupport.ts
+++ b/client/src/utils/checkWebPSupport.ts
@@ -1,0 +1,4 @@
+export function checkWebPSupport() {
+  const canvas = document.createElement('canvas');
+  return canvas.toDataURL('image/webp').indexOf('data:image/webp') === 0;
+}

--- a/client/src/utils/getCanvasUint8Array.ts
+++ b/client/src/utils/getCanvasUint8Array.ts
@@ -1,10 +1,18 @@
 import { RefObject } from 'react';
+import { checkWebPSupport } from './checkWebPSupport';
 
 type Format = 'image/png' | 'image/jpeg' | 'image/webp';
 
 export async function getCanvasUint8Array(canvasRef: RefObject<HTMLCanvasElement>, format: Format, quality?: number) {
   const canvas = canvasRef.current;
   if (!canvas) return;
+
+  let supportedFormat: Format = format;
+
+  if (format === 'image/webp') {
+    const webpSupported = checkWebPSupport();
+    supportedFormat = webpSupported ? 'image/webp' : 'image/jpeg';
+  }
 
   const blob = await new Promise<Blob>((resolve, reject) => {
     canvas.toBlob(
@@ -15,7 +23,7 @@ export async function getCanvasUint8Array(canvasRef: RefObject<HTMLCanvasElement
         }
         resolve(blob);
       },
-      format,
+      supportedFormat,
       quality,
     );
   });

--- a/client/src/utils/getCanvasUint8Array.ts
+++ b/client/src/utils/getCanvasUint8Array.ts
@@ -3,6 +3,24 @@ import { checkWebPSupport } from './checkWebPSupport';
 
 type Format = 'image/png' | 'image/jpeg' | 'image/webp';
 
+/**
+ * 캔버스 요소를 지정된 이미지 형식으로 변환하고, `Uint8Array`로 반환합니다.
+ * WebP 형식을 요청했지만 지원되지 않는 경우 JPEG로 대체됩니다.
+ *
+ * @param {RefObject<HTMLCanvasElement>} canvasRef - 캔버스 요소를 가리키는 React ref 객체.
+ * @param {Format} format - 원하는 이미지 형식 ('image/png', 'image/jpeg', 'image/webp').
+ * @param {number} [quality] - 손실 압축 형식(JPEG/WebP)의 경우 품질 (0~1 범위).
+ * @returns {Promise<Uint8Array | undefined>} 이미지 데이터를 포함하는 `Uint8Array` 또는 캔버스가 없을 경우 `undefined`.
+ *
+ * @throws {Error} 캔버스에서 Blob 생성에 실패하면 오류가 발생합니다.
+ *
+ * @example
+ * ```typescript
+ * const uint8Array = await getCanvasUint8Array(canvasRef, 'image/webp', 0.8);
+ * ```
+ * @category Utils
+ */
+
 export async function getCanvasUint8Array(canvasRef: RefObject<HTMLCanvasElement>, format: Format, quality?: number) {
   const canvas = canvasRef.current;
   if (!canvas) return;

--- a/client/src/utils/getCanvasUint8Array.ts
+++ b/client/src/utils/getCanvasUint8Array.ts
@@ -1,15 +1,23 @@
 import { RefObject } from 'react';
 
-export async function getCanvasUint8Array(canvasRef: RefObject<HTMLCanvasElement>) {
+type Format = 'image/png' | 'image/jpeg' | 'image/webp';
+
+export async function getCanvasUint8Array(canvasRef: RefObject<HTMLCanvasElement>, format: Format, quality?: number) {
   const canvas = canvasRef.current;
   if (!canvas) return;
-  const blob = await new Promise<Blob>((resolve) => {
-    canvas.toBlob((blob) => {
-      if (!blob) {
-        throw new Error('Failed to create blob from canvas');
-      }
-      resolve(blob);
-    });
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('Failed to create blob from canvas'));
+          return;
+        }
+        resolve(blob);
+      },
+      format,
+      quality,
+    );
   });
 
   const arrayBuffer = await blob.arrayBuffer();


### PR DESCRIPTION
## 📂 작업 내용

closes #40 

- [x] 캔버스 이미지 용량 최적화 

## 💡 자세한 설명

### webp로 캔버스 이미지 추출

- 서버 트래픽을 줄이기 위해 비교적 용량이 적은 webp로 이미지를 추출하도록 변경하였습니다. 
- 캔버스를 blob 객체로 바꿀 때, format을 webp, quality를 0.8로 설정하여 캔버스 이미지를 webp로 추출합니다.
- quality를 0.8로 설정한 이유는 파일 크기와 화질의 균형을 잘 맞출 수 있어, 최적의 성능을 제공하기 때문입니다. 

### webp를 지원하지 않는 브라우저 대응

- WebP 지원 여부는 `canvas.toDataURL('image/webp')`를 사용하여 생성된 URL의 메타데이터가 webp인지 확인합니다.
- WebP를 지원하는 경우 WebP 포맷을 사용하여 이미지를 추출하고, 그렇지 않으면 JPEG 포맷을 사용합니다. 


### 결과

- jpeg -> webp: 50% 파일 크기 감소 

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

- 포맷별 동일한 그림데이터일 때 용량 얼마나 차이나는지 테스트 코드 작성

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
